### PR TITLE
Inject instance of Logger into use case interactor

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 	orderInteractor.UserRepository = interfaces.NewDbUserRepo(handlers)
 	orderInteractor.ItemRepository = interfaces.NewDbItemRepo(handlers)
 	orderInteractor.OrderRepository = interfaces.NewDbOrderRepo(handlers)
+	orderInteractor.Logger = new(infrastructure.Logger)
 
 	webserviceHandler := interfaces.WebserviceHandler{}
 	webserviceHandler.OrderInteractor = orderInteractor

--- a/src/infrastructure/logger.go
+++ b/src/infrastructure/logger.go
@@ -1,12 +1,11 @@
 package infrastructure
 
 import (
-	"fmt"
+	"log"
 )
 
 type Logger struct{}
 
-func (logger Logger) Log(message string) error {
-	fmt.Println("Log message: " + message)
-	return nil
+func (logger Logger) Log(args ...interface{}) {
+	log.Println(args...)
 }

--- a/src/usecases/usecases.go
+++ b/src/usecases/usecases.go
@@ -23,7 +23,7 @@ type Item struct {
 }
 
 type Logger interface {
-	Log(message string) error
+	Log(args ...interface{})
 }
 
 type OrderInteractor struct {
@@ -38,9 +38,9 @@ func (interactor *OrderInteractor) Items(userId, orderId int) ([]Item, error) {
 	user := interactor.UserRepository.FindById(userId)
 	order := interactor.OrderRepository.FindById(orderId)
 	if user.Customer.Id != order.Customer.Id {
-		message := "User #%i (customer #%i) "
+		message := "User #%d (customer #%d) "
 		message += "is not allowed to see items "
-		message += "in order #%i (of customer #%i)"
+		message += "in order #%d (of customer #%d)"
 		err := fmt.Errorf(message,
 			user.Id,
 			user.Customer.Id,
@@ -62,9 +62,9 @@ func (interactor *OrderInteractor) Add(userId, orderId, itemId int) error {
 	user := interactor.UserRepository.FindById(userId)
 	order := interactor.OrderRepository.FindById(orderId)
 	if user.Customer.Id != order.Customer.Id {
-		message = "User #%i (customer #%i) "
+		message = "User #%d (customer #%d) "
 		message += "is not allowed to add items "
-		message += "to order #%i (of customer #%i)"
+		message += "to order #%d (of customer #%d)"
 		err := fmt.Errorf(message,
 			user.Id,
 			user.Customer.Id,
@@ -75,9 +75,9 @@ func (interactor *OrderInteractor) Add(userId, orderId, itemId int) error {
 	}
 	item := interactor.ItemRepository.FindById(itemId)
 	if domainErr := order.Add(item); domainErr != nil {
-		message = "Could not add item #%i "
-		message += "to order #%i (of customer #%i) "
-		message += "as user #%i because a business "
+		message = "Could not add item #%d "
+		message += "to order #%d (of customer #%d) "
+		message += "as user #%d because a business "
 		message += "rule was violated: '%s'"
 		err := fmt.Errorf(message,
 			item.Id,
@@ -90,7 +90,7 @@ func (interactor *OrderInteractor) Add(userId, orderId, itemId int) error {
 	}
 	interactor.OrderRepository.Store(order)
 	interactor.Logger.Log(fmt.Sprintf(
-		"User added item '%s' (#%i) to order #%i",
+		"User added item '%s' (#%d) to order #%d",
 		item.Name, item.Id, order.Id))
 	return nil
 }
@@ -104,9 +104,9 @@ func (interactor *AdminOrderInteractor) Add(userId, orderId, itemId int) error {
 	user := interactor.UserRepository.FindById(userId)
 	order := interactor.OrderRepository.FindById(orderId)
 	if !user.IsAdmin {
-		message = "User #%i (customer #%i) "
+		message = "User #%d (customer #%d) "
 		message += "is not allowed to add items "
-		message += "to order #%i (of customer #%i), "
+		message += "to order #%d (of customer #%d), "
 		message += "because he is not an administrator"
 		err := fmt.Errorf(message,
 			user.Id,
@@ -118,9 +118,9 @@ func (interactor *AdminOrderInteractor) Add(userId, orderId, itemId int) error {
 	}
 	item := interactor.ItemRepository.FindById(itemId)
 	if domainErr := order.Add(item); domainErr != nil {
-		message = "Could not add item #%i "
-		message += "to order #%i (of customer #%i) "
-		message += "as user #%i because a business "
+		message = "Could not add item #%d "
+		message += "to order #%d (of customer #%d) "
+		message += "as user #%d because a business "
 		message += "rule was violated: '%s'"
 		err := fmt.Errorf(message,
 			item.Id,
@@ -133,7 +133,7 @@ func (interactor *AdminOrderInteractor) Add(userId, orderId, itemId int) error {
 	}
 	interactor.OrderRepository.Store(order)
 	interactor.Logger.Log(fmt.Sprintf(
-		"Admin added item '%s' (#%i) to order #%i",
+		"Admin added item '%s' (#%d) to order #%d",
 		item.Name, item.Id, order.Id))
 	return nil
 }


### PR DESCRIPTION
Without this fix, if you run though code that exercises the Logger like requesting this URL...

`http://localhost:8080/orders?userId=10&orderId=60`

... You will likely get a stack trace that looks like this:

```
2017/06/19 23:26:49 http: panic serving [::1]:51108: runtime error: invalid memory address or nil pointer dereference
goroutine 6 [running]:
net/http.(*conn).serve.func1(0xc4200dc6e0)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:1721 +0xd0
panic(0x43ef2c0, 0x45cdec0)
	/usr/local/Cellar/go/1.8.3/libexec/src/runtime/panic.go:489 +0x2cf
usecases.(*OrderInteractor).Items(0xc420014640, 0xa, 0x3c, 0x0, 0x0, 0xc420110f70, 0xe, 0xc4200fcae4)
	/Users/lex/clients/kryptos/dev-lean/go/src/github.com/l3x/go-cleanarchitecture/src/usecases/usecases.go:49 +0x49a
interfaces.WebserviceHandler.ShowOrder(0x45a9b20, 0xc420014640, 0x45aae60, 0xc42011a0e0, 0xc420076400)
	/Users/lex/clients/kryptos/dev-lean/go/src/github.com/l3x/go-cleanarchitecture/src/interfaces/webservice.go:23 +0xe3
main.main.func1(0x45aae60, 0xc42011a0e0, 0xc420076400)
	/Users/lex/clients/kryptos/dev-lean/go/src/github.com/l3x/go-cleanarchitecture/main.go:28 +0x51
net/http.HandlerFunc.ServeHTTP(0xc4200ce8c0, 0x45aae60, 0xc42011a0e0, 0xc420076400)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:1942 +0x44
net/http.(*ServeMux).ServeHTTP(0x45d8fe0, 0x45aae60, 0xc42011a0e0, 0xc420076400)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:2238 +0x130
net/http.serverHandler.ServeHTTP(0xc4200a82c0, 0x45aae60, 0xc42011a0e0, 0xc420076400)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc4200dc6e0, 0x45ab360, 0xc4200ee040)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:2668 +0x2ce
```

After applying this PR, this is what you're likely to see in the logs (instead of the stack trace):

```
 $ go-cleanarchitecture
2017/06/20 09:37:17 User #10 (customer #0) is not allowed to see items in order #60 (of customer #50)
```